### PR TITLE
Adds propertyList to Situation(Mention) and Entity(Mention)

### DIFF
--- a/thrift/entities.thrift
+++ b/thrift/entities.thrift
@@ -9,6 +9,7 @@ namespace py concrete.entities
 namespace cpp concrete
 #@namespace scala edu.jhu.hlt.miser
 
+include "property.thrift"
 include "structure.thrift"
 include "metadata.thrift"
 include "uuid.thrift"
@@ -87,6 +88,13 @@ struct Entity {
    * mentions' text strings, but it is not required to. 
    */
   5: optional string canonicalName
+
+  /**
+   * For multi-label tasks, more than one property can be attached to 
+   * a single entity. A list of these properties can be stored in 
+   * this field.
+   */
+  8: optional list<Property> propertyList
 }
 
 /** 
@@ -203,6 +211,12 @@ struct EntityMention {
    */
   7: optional list<uuid.UUID> childMentionIdList
 
+  /**
+   * For multi-label tasks, more than one property can be attached to 
+   * a single entity mention. A list of these properties can be stored 
+   * in this field.
+   */
+  9: optional list<Property> propertyList
 }
 
 

--- a/thrift/property.thrift
+++ b/thrift/property.thrift
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2014 Johns Hopkins University HLTCOE. All rights reserved.
+ * This software is released under the 2-clause BSD license.
+ * See LICENSE in the project root directory.
+ */
+
+namespace java edu.jhu.hlt.concrete
+namespace py concrete.situations
+namespace cpp concrete
+#@namespace scala edu.jhu.hlt.miser
+
+/**
+ * Attached to situations, entities, or arguments (or mentions thereof)
+ * to support multi-label annotations.
+ */
+struct Property {
+  /**
+   * The required value of the property.
+   */
+  1: required string value
+  
+  /**
+   * Metadata to support this particular property object.
+   */  
+  2: required metadata.AnnotationMetadata metadata
+  
+  /** 
+   * This value is typically boolean, 0.0 or 1.0, but we use a
+   * float in order to potentially capture cases where an annotator is
+   * highly confident that the value is underspecified, via a value of
+   * 0.5.  
+   */
+  3: optional double polarity
+}

--- a/thrift/situations.thrift
+++ b/thrift/situations.thrift
@@ -9,35 +9,12 @@ namespace py concrete.situations
 namespace cpp concrete
 #@namespace scala edu.jhu.hlt.miser
 
+include "property.thrift"
 include "structure.thrift"
 include "metadata.thrift"
 include "uuid.thrift"
 include "linking.thrift"
 
-/**
- * Attached to Arguments to support situations where
- * a 'participant' has more than one 'property' (in BinarySRL terms),
- * whereas Arguments notionally only support one Role. 
- */
-struct Property {
-  /**
-   * The required value of the property.
-   */
-  1: required string value
-  
-  /**
-   * Metadata to support this particular property object.
-   */  
-  2: required metadata.AnnotationMetadata metadata
-  
-  /** 
-   * This value is typically boolean, 0.0 or 1.0, but we use a
-   * float in order to potentially capture cases where an annotator is
-   * highly confident that the value is underspecified, via a value of
-   * 0.5.  
-   */
-  3: optional double polarity
-}
 
 /** 
  * A situation argument, consisting of an argument role and a value.
@@ -64,9 +41,9 @@ struct Argument {
   3: optional uuid.UUID situationId
   
   /**
-   * For the BinarySRL task, there may be situations
-   * where more than one property is attached to a single
-   * participant. A list of these properties can be stored in this field.
+   * For multi-label tasks, more than one property can be attached to 
+   * a single participant. A list of these properties can be stored in 
+   * this field.
    */
   4: optional list<Property> propertyList
 }
@@ -219,6 +196,13 @@ struct Situation {
    * SituationSet's metadata. 
    */
   200: optional double confidence
+
+  /**
+   * For multi-label tasks, more than one property can be attached to 
+   * a single situation. A list of these properties can be stored in 
+   * this field.
+   */
+  300: optional list<Property> propertyList
 }
 
 /** 
@@ -292,9 +276,9 @@ struct MentionArgument {
   5: optional double confidence
 
   /**
-   * For the BinarySRL task, there may be situations
-   * where more than one property is attached to a single
-   * participant. A list of these properties can be stored in this field.
+   * For multi-label tasks, more than one property can be attached to 
+   * a single participant. A list of these properties can be stored in 
+   * this field.
    */
   6: optional list<Property> propertyList
 
@@ -402,6 +386,13 @@ struct SituationMention {
    * using the SituationMentionSet's metadata. 
    */
   200: optional double confidence
+
+  /**
+   * For multi-label tasks, more than one property can be attached to 
+   * a single situation mention. A list of these properties can be 
+   * stored in this field.
+   */
+  300: optional list<Property> propertyList
 }
 
 /** 


### PR DESCRIPTION
This pull request:

1. Refactors `Property` into its own module (`property.thrift`)
2. Adds a `propertyList` attribute to `Situation`s, `SituationMention`, `Entity`s, and `EntityMention`s.

Addition of `propertyList` attributes to these four `struct`s is driven by the need to represent general multi-label annotations, such as [Universal Decompositional Semantics](https://github.com/decompositional-semantics-initiative/decomp), on `Situation`s, `SituationMention`, `Entity`s, and `EntityMention`s. Currently, multi-label annotation (under the guise of the now deprecated task name "BinarySRL") is only supported for `Argument`s and `ArgumentMention`s. 